### PR TITLE
Adding ScaleIO 2.5 compatibility

### DIFF
--- a/lib/puppet/provider/scaleio_sds/scli.rb
+++ b/lib/puppet/provider/scaleio_sds/scli.rb
@@ -122,8 +122,13 @@ Puppet::Type.type(:scaleio_sds).provide(:scli) do
         end
       end
     end
-    @resource[:rfcache_devices].each do |rfcache_device|
-      scli("--add_sds_rfcache_device", "--sds_name", @resource[:name], "--rfcache_device_path", rfcache_device)
+    Puppet.debug("Managing rfcache")
+    if @resource[:rfcache] == 'enabled'
+      @resource[:rfcache_devices].each do |rfcache_device|
+        scli("--add_sds_rfcache_device", "--sds_name", @resource[:name], "--rfcache_device_path", rfcache_device)
+      end
+    else
+      self.rfcache = @resource[:rfcache]
     end
     @property_hash[:ensure] = :present
   end

--- a/manifests/lia.pp
+++ b/manifests/lia.pp
@@ -18,10 +18,10 @@ class scaleio::lia{
 
   # Setting environment variables is not supported by package
   # but this is needed for setting the LIA password
-  exec {"yum install -y 'EMC-ScaleIO-lia${real_version}'":
+  exec {"/usr/bin/yum install -y 'EMC-ScaleIO-lia${real_version}'":
     environment => [ "TOKEN=${scaleio::password}" ],
     tag         => 'scaleio-install',
-    unless      => "rpm -q 'EMC-ScaleIO-lia${real_version}'",
+    unless      => "/usr/bin/rpm -q 'EMC-ScaleIO-lia${real_version}'",
     require     => Package_verifiable::Yum::Versionlock['EMC-ScaleIO-lia']
   } ->
   service{'lia':

--- a/manifests/mdm/cluster_setup.pp
+++ b/manifests/mdm/cluster_setup.pp
@@ -5,18 +5,19 @@ class scaleio::mdm::cluster_setup {
   $primary_mdm_mgmt_ips = join(any2array($::scaleio::mdms[$::scaleio::bootstrap_mdm_name]['mgmt_ips']), ',')
 
   exec{ 'scaleio::mdm::cluster_setup::create_cluster':
-    command => "scli --create_mdm_cluster --master_mdm_ip ${primary_mdm_ips} --master_mdm_name ${::scaleio::bootstrap_mdm_name} --use_nonsecure_communication --accept_license; sleep 5",
-    onlyif  => 'scli --query_cluster --approve_certificate 2>&1 |grep -qE "Error: MDM failed command.  Status: (This MDM is not attached to a system.|The MDM cluster state is incorrect)"',
+    command => "/opt/emc/scaleio/mdm/bin/cli --create_mdm_cluster --master_mdm_ip ${primary_mdm_ips} --master_mdm_name ${::scaleio::bootstrap_mdm_name} --use_nonsecure_communication --accept_license; sleep 5",
+    onlyif  => '/opt/emc/scaleio/mdm/bin/cli --query_cluster --approve_certificate 2>&1 |grep -qE "Error: MDM failed command.  Status: (This MDM is not attached to a system.|The MDM cluster state is incorrect)"',
     require => Exec['scaleio::mdm::installation::restart_mdm'],
   }->
   exec{ 'scaleio::mdm::cluster_setup::login_default':
-    command => "scli --login --username admin --password ${::scaleio::old_password}",
-    unless  => "scli --login --username admin --password ${::scaleio::password} && scli --logout",
+    command => "/opt/emc/scaleio/mdm/bin/cli --login --username admin --password ${::scaleio::old_password}",
+    unless  => "/opt/emc/scaleio/mdm/bin/cli --login --username admin --password ${::scaleio::password} && scli --logout",
   } ~>
   exec{ 'scaleio::mdm::cluster_setup::primary_change_pwd':
-    command     => "scli --set_password --old_password ${::scaleio::old_password} --new_password ${scaleio::password}",
+    command     => "/opt/emc/scaleio/mdm/bin/cli --set_password --old_password ${::scaleio::old_password} --new_password ${scaleio::password}",
     refreshonly => true,
   }
+
 
   # wait until the MDM/TBs have been setup
   if $scaleio::use_consul{
@@ -45,6 +46,7 @@ class scaleio::mdm::cluster_setup {
     is_tiebreaker => true,
     require       => Exec['scaleio::mdm::cluster_setup::primary_change_pwd']
   })
+
 
   Scaleio_mdm<||> -> Scaleio_mdm_cluster<||>
 

--- a/manifests/mdm/installation.pp
+++ b/manifests/mdm/installation.pp
@@ -34,7 +34,7 @@ class scaleio::mdm::installation(
   } ~>
   exec{ 'scaleio::mdm::installation::restart_mdm':
     # give the mdm time to switch its role
-    command     => 'systemctl restart mdm.service; sleep 15',
+    command     => '/usr/bin/systemctl restart mdm.service; /usr/bin/sleep 15',
     refreshonly => true,
   }
 

--- a/manifests/mdm/primary.pp
+++ b/manifests/mdm/primary.pp
@@ -21,9 +21,9 @@ class scaleio::mdm::primary {
 
   # manage SDC restriction mode
   if $::scaleio::restricted_sdc_mode{
-    $restricted_sdc_mode_text = 'enabled'
+    $restricted_sdc_mode_text = 'guid'
   } else{
-    $restricted_sdc_mode_text = 'disabled'
+    $restricted_sdc_mode_text = 'none'
   }
 
   exec{ 'scaleio::mdm::primary::manage_sdc_access_restriction':

--- a/manifests/rpmkey.pp
+++ b/manifests/rpmkey.pp
@@ -8,7 +8,7 @@ class scaleio::rpmkey {
       mode   => '0644',
   } ~>
   exec { 'scaleio::rpmkey::import' :
-    command     => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-ScaleIO',
+    command     => '/usr/bin/rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-ScaleIO',
     refreshonly => true,
   }
 }

--- a/manifests/sdc.pp
+++ b/manifests/sdc.pp
@@ -23,13 +23,13 @@ class scaleio::sdc {
     # add at first time MDM, if no one is defined
     exec{'scaleio::sdc_add_mdm':
       command => "/bin/emc/scaleio/drv_cfg --add_mdm --ip ${mdm_ips_joined} --file /bin/emc/scaleio/drv_cfg.txt",
-      unless  => "grep -qE '^mdm ' /bin/emc/scaleio/drv_cfg.txt",
+      unless  => "/usr/bin/grep -qE '^mdm ' /bin/emc/scaleio/drv_cfg.txt",
     }->
 
     # replace or add MDM definition
     exec{'scaleio::sdc_mod_mdm':
       command => "/bin/emc/scaleio/drv_cfg --mod_mdm_ip --ip $(grep -E '^mdm' /bin/emc/scaleio/drv_cfg.txt |awk '{print \$2}' |awk -F ',' '{print \$1}') --new_mdm_ip ${mdm_ips_joined} --file /bin/emc/scaleio/drv_cfg.txt",
-      unless  => "grep -qE '^mdm ${mdm_ips_joined}$' /bin/emc/scaleio/drv_cfg.txt",
+      unless  => "/usr/bin/grep -qE '^mdm ${mdm_ips_joined}$' /bin/emc/scaleio/drv_cfg.txt",
     }
   }
 


### PR DESCRIPTION
and fixes to allow the absence of rfcache_devices variable within the first puppet run